### PR TITLE
Fix: Start-Stop

### DIFF
--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type TimerInterface = [
+    number,
+    {
+        start: Function,
+        stop: Function,
+        reset: Function
+    }
+]
+
+export default function useTimer(time: number): TimerInterface {
+
+    const [counter, setCounter] = useState<number>(time);
+    const timer = useRef<number | null>(null);
+    const isTimerEnded = counter <= 0;
+
+    const start = useCallback(function () {
+        if (timer.current !== null || isTimerEnded) return;
+
+        const interval_handler = () => {
+            setCounter((prevCounter) => prevCounter - 1);
+        }
+
+        timer.current = setInterval(interval_handler, 1000);
+    }, [timer, isTimerEnded, setCounter]);
+
+    const stop = useCallback(function () {
+        if (timer.current) clearInterval(timer.current);
+        timer.current = null;
+    }, [timer]);
+
+    const reset = useCallback(function () {
+        stop();
+        setCounter(time);
+    }, [stop, time, setCounter]);
+
+    useEffect(() => {
+
+        if (isTimerEnded) stop();
+
+        return () => {
+            stop();
+        }
+
+    }, [isTimerEnded, stop]);
+
+    useEffect(() => {
+        return () => {
+            stop();
+        }
+    }, [stop]);
+
+    return [counter, { start, stop, reset }];
+
+}


### PR DESCRIPTION
There was a bug in the hook: when you paused the counter you couldn't start it again (except with the reset function). Now you can pause the counter and start it as many times as you want as long as the counter is greater than zero